### PR TITLE
Minor changes regarding counting and psql initialization

### DIFF
--- a/neo/core/__init__.py
+++ b/neo/core/__init__.py
@@ -141,12 +141,7 @@ class NeoBot(commands.Bot):
 
     async def __ainit__(self):
         self.session = aiohttp.ClientSession()
-        self.pool = await asyncpg.create_pool(
-            user=neo.secrets.dbuser,
-            password=neo.secrets.dbpass,
-            database=neo.secrets.db,
-            host=neo.secrets.dbhost,
-        )
+        self.pool = await asyncpg.create_pool(**neo.secrets.database)
         self.user_cache = await DbCache(
             db_query="SELECT * FROM user_data", key="user_id", pool=self.pool
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+git+https://github.com/Rapptz/discord-ext-menus
+
 discord.py
 humanize
 python-dateutil


### PR DESCRIPTION
Basically i moved all keys in `secret` that started with `db` into their own mapping where it makes the config and the code look nicer. All you have to do is make `secrets.database` able to be unpacked into kwargs for `asyncpg.Pool.connect`, like this
```yml
secret:
  bot_token: 'token'
  database:
    host: 'localhost'
    user: 'equity'
    password: 'equity'
    database: 'neo'
```

I also made it where the counting channel feature is a bit more tolerant to stupid things that people can do (for example edit messages to fool people) so any edited messages in the channel configured to be used for counting will be deleted and it should decrement the counter if it was the newest message in the channel, if that's not the case anyone can use the `counting` command  to see the current statistics, but don't worry they can't set anything. 

If i missed anything i'll either edit this message or send another one in this PR